### PR TITLE
FE: Tailwind config - Colors and Fonts (#86a3f29c0)

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { inter, ubuntu } from '../fonts';
+import "../globals.css";
 import { getDictionary } from './dictionaries'
 import { DictionarySetter } from '@/components/config'
 
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -22,7 +22,7 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${inter.variable} ${ubuntu.variable}`}>
         <DictionarySetter dictionary={dictionary} />
         {children}
       </body>

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,9 +1,15 @@
 export default function RootPage() {
   return (
-    <div className="h-screen flex justify-center items-center">
-      <h1 className="text-9xl text-teal-500 font-extrabold font-mono">
-        Root Page
+    <div className="min-h-screen flex flex-col justify-center items-center">
+      <h1 className="text-9xl text-darkPurple font-display">
+        RootPage
       </h1>
+      <p className="text-orange font-sans">
+        TestParagraph
+      </p>
+      <p className="text-orange font-sans font-bold">
+        TestParagraphBold
+      </p>
     </div>
   )
 }

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,0 +1,17 @@
+import { Inter, Ubuntu } from "next/font/google";
+
+export const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+  weight: "variable",
+  fallback: ["system-ui", "arial"],
+});
+
+export const ubuntu = Ubuntu({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-ubuntu",
+  weight: "700",
+  fallback: ["system-ui", "arial"],
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,27 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        "darkPurple": "#533ABA",
+        "brightPurple": "#7300FE",
+        "orange": "#FFB252",
+        "peach": "#FFDBB9",
+        "redError": "#D6293E",
+        "greenSuccess": "#9BDA4B",
+        "white": "#FFF8FF",
+        "black": "#0E0E0E",
+        "gray": {
+          "100": "#E5E5E5",
+          "300": "#B4B4B4",
+          "500": "#383838",
+          "700": "#252525",
+          "900": "#1E1E1E",
+        }
+      },
+      fontFamily: {
+        sans: ["var(--font-inter)"],
+        display: ["var(--font-ubuntu)"],
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/86a3f29c0

- Agrego las tipografías Inter + Ubuntu en el archivo `app/fonts.ts` 
- Configuro nuevas fuentes en el root Layout `app/[lang]/layout.tsx`
- Agrego las tipografías al tema por defecto de Tailwind CSS: Inter como `font-sans` y Ubuntu como `font-display`
- Configuro los colores adicionales en `tailwind.config.ts` siguiendo los nombres detallados en el archivo de Figma que contiene el diseño
- Agrego `globals.css` para poder aplicar las directivas principales, necesarias para el funcionamiento del tailwind theme
- Agrego textos y estilos de prueba en `app/[lang]/page.tsx` para probar el correcto funcionamiento de los nuevos colores y fonts